### PR TITLE
New feature: Prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ There are 5 commands supported by the aip-man:
   + Usage: `aipman run <app-name>`
   + This command will run one of your installed apps, so you don't have to navigate to the install directory to launch them.
 
+Additionally, if you want to review changes first, you can add the --ask/-a tag which will cause the application to ask you if you want to continue. Defaults to yes.
+
 ## Contributing
 
 Please contribute! Add packages to the [global package listing](https://raw.githubusercontent.com/blueOkiris/aip-man-pkg-list/main/pkgs.json) or improve the tool itself. I'd love your help!

--- a/src/args.rs
+++ b/src/args.rs
@@ -3,12 +3,18 @@
  * Description: Parse cli arguments
  */
 
-use clap::{Parser, Subcommand};
+use clap::{
+    Parser, Subcommand
+};
 
 /// Structure defining CLI command and arguments.
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
+    /// Ask before changing package information
+    #[arg(short, long)]
+    pub ask: bool,
+
     /// One of the commands: install <pkg>, remove <pkg>, upgrade, etc.
     #[command(subcommand)]
     pub command: Commands


### PR DESCRIPTION
If requested, prompt the user before installing/removing/upgrading.
This is a feature every package manager has by default, so it makes sense to add.

Because of the nature of AppImages, I don't think it makes sense to really ask really ever and personally, I never will, but I felt it should be included as an option, hence why it is non-default to prompt the user.

Tested by installing/removing/upgrading lmms and attempting to cancel each of those operations as well as continue them.