### PR TITLE
New Feature: Add terminal arguments to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ There are 5 commands supported by the aip-man:
   + Usage: `aipman list`
   + List out installed packages.
 - Run
-  + Usage: `aipman run <app-name>`
+  + Usage: `aipman run <app-name> [args]...`
   + This command will run one of your installed apps, so you don't have to navigate to the install directory to launch them.
+  + You can also pass any number of arguments to the AppImage if you so choose.
 
 Additionally, if you want to review changes first, you can add the --ask/-a tag which will cause the application to ask you if you want to continue. Defaults to yes.
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -43,7 +43,10 @@ pub enum Commands {
     /// Run an installed application.
     Run {
         /// Installed application to run.
-        app: String
+        app: String,
+
+        /// Arguments to pass to the application.
+        app_args: Option<Vec<String>>
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,9 @@ fn main() {
         Commands::Remove { package } => remove_package(&package, args.ask),
         Commands::Upgrade => upgrade_packages(args.ask),
         Commands::List => list_packages(),
-        Commands::Run { app } => run_app(&app, args.ask)
+        Commands::Run { app, app_args } => run_app(
+            &app, &app_args.unwrap_or(Vec::new()), args.ask
+        )
     }
 }
 
@@ -160,7 +162,7 @@ fn list_packages() {
 }
 
 /// Execute an application
-fn run_app(app_name: &str, ask: bool) {
+fn run_app(app_name: &str, app_args: &Vec<String>, ask: bool) {
     let manifest = get_pkg_manifest();
     if !manifest.iter().any(|pkg| pkg.name == app_name) {
         println!("No such package '{}' installed!", app_name);
@@ -168,7 +170,7 @@ fn run_app(app_name: &str, ask: bool) {
     }
 
     if prompt(format!("Are you sure you want to run '{}'?", app_name).as_str(), ask) {
-        manifest.iter().find(|pkg| pkg.name == app_name).unwrap().run();
+        manifest.iter().find(|pkg| pkg.name == app_name).unwrap().run(app_args);
     }
 }
 

--- a/src/pkg.rs
+++ b/src/pkg.rs
@@ -88,7 +88,7 @@ impl Package {
         )).expect("Failed to delete package");
     }
 
-    pub fn run(&self) {
+    pub fn run(&self, args: &Vec<String>) {
         let mut app_dir = home_dir().expect(
             "Um. Somehow you don't have a home directory. You can't use this tool"
         );
@@ -97,7 +97,7 @@ impl Package {
             "{}/{}-{}.AppImage", app_dir.as_os_str().to_str().unwrap(), self.name, self.version
         );
 
-        Command::new(file_name).output().expect("Failed to start app");
+        Command::new(file_name).args(args).output().expect("Failed to start app");
     }
 }
 


### PR DESCRIPTION
Some AppImages are terminal applications that take cli arguments such as pkg2appimage.

These will need arguments and cannot therefore make use of the current `aipman run` command.

This set of changes adds that capability.