### PR TITLE
Implement simple backup/restore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,14 +3,22 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aipman"
-version = "6.0.0"
+version = "7.0.0"
 dependencies = [
  "clap",
  "dirs",
+ "flate2",
  "reqwest",
  "serde",
  "serde_json",
+ "tar",
  "version-compare",
 ]
 
@@ -110,6 +118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +183,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -404,7 +443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -422,7 +461,7 @@ dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -480,6 +519,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,7 +536,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -719,7 +767,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -734,7 +782,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -840,6 +888,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,7 +970,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1159,6 +1218,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,4 +1290,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aipman"
 authors = [ "Dylan Turner <dylantdmt@gmail.com>" ]
-version = "6.0.0"
+version = "7.0.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "The AppImage Package Manager"
@@ -19,3 +19,6 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0.91"
 dirs = "4.0.0"
 version-compare = "0.1.1"
+flate2 = "1.0.25"
+tar = "0.4.38"
+

--- a/README.md
+++ b/README.md
@@ -32,8 +32,13 @@ There are 5 commands supported by the aip-man:
   + Usage: `aipman run <app-name> [args]...`
   + This command will run one of your installed apps, so you don't have to navigate to the install directory to launch them.
   + You can also pass any number of arguments to the AppImage if you so choose.
+- Restore
+  + Usage: `aipman restore`
+  + This command will take the backup file `.aipman_backup.tar.gz` and unpack it where ~/Applications used to be.
 
-Additionally, if you want to review changes first, you can add the --ask/-a tag which will cause the application to ask you if you want to continue. Defaults to yes.
+There are two additional options that can be passed in before providing a subcommand:
+- If you want to review changes first, you can add the --ask/-a tag which will cause the application to ask you if you want to continue. Defaults to yes.
+- If you want to create a backup before making a change, you can use the --backup/-b tag that can be restored from via `aipman restore`
 
 ## Contributing
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,6 +15,10 @@ pub struct Args {
     #[arg(short, long)]
     pub ask: bool,
 
+    /// Create a backup of ~/Applications that can be restored from
+    #[arg(short, long)]
+    pub backup: bool,
+
     /// One of the commands: install <pkg>, remove <pkg>, upgrade, etc.
     #[command(subcommand)]
     pub command: Commands
@@ -47,6 +51,9 @@ pub enum Commands {
 
         /// Arguments to pass to the application.
         app_args: Option<Vec<String>>
-    }
+    },
+
+    /// Restore ~/Applications from backup
+    Restore
 }
 

--- a/src/pkg.rs
+++ b/src/pkg.rs
@@ -28,7 +28,7 @@ use version_compare::{
 
 const PKG_LIST_URL: &'static str =
     "https://raw.githubusercontent.com/blueOkiris/aip-man-pkg-list/main/pkgs.json";
-const APP_DIR: &'static str = "Applications"; 
+pub const APP_DIR: &'static str = "Applications"; 
 
 /// Structure used to parse JSON info from package list.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -62,9 +62,8 @@ impl Package {
 
     pub fn download(&self) {
         // First, create the /home/AppImages directory if it doesn't exist
-        let mut app_dir = home_dir().expect(
-            "Um. Somehow you don't have a home directory. You can't use this tool"
-        );
+        let mut app_dir = home_dir()
+            .expect("Um. Somehow you don't have a home directory. You can't use this tool");
         app_dir.push(APP_DIR);
         create_dir_all(app_dir.clone()).expect("Failed to create Application path");
 
@@ -81,9 +80,8 @@ impl Package {
     }
 
     pub fn remove(&self) {
-        let mut app_dir = home_dir().expect(
-            "Um. Somehow you don't have a home directory. You can't use this tool"
-        );
+        let mut app_dir = home_dir()
+            .expect("Um. Somehow you don't have a home directory. You can't use this tool");
         app_dir.push(APP_DIR);
         remove_file(format!(
             "{}/{}-{}.AppImage", app_dir.as_os_str().to_str().unwrap(), self.name, self.version
@@ -91,9 +89,8 @@ impl Package {
     }
 
     pub fn run(&self, args: &Vec<String>) {
-        let mut app_dir = home_dir().expect(
-            "Um. Somehow you don't have a home directory. You can't use this tool"
-        );
+        let mut app_dir = home_dir()
+            .expect("Um. Somehow you don't have a home directory. You can't use this tool");
         app_dir.push(APP_DIR);
         let file_name = format!(
             "{}/{}-{}.AppImage", app_dir.as_os_str().to_str().unwrap(), self.name, self.version
@@ -120,9 +117,8 @@ pub fn pull_package_list() -> Vec<Package> {
 /// Read (or create) the installed package manifest
 pub fn get_pkg_manifest() -> Vec<Package> {
     // First, create the /home/AppImages directory if it doesn't exist
-    let mut app_dir = home_dir().expect(
-        "Um. Somehow you don't have a home directory. You can't use this tool"
-    );
+    let mut app_dir = home_dir()
+        .expect("Um. Somehow you don't have a home directory. You can't use this tool");
     app_dir.push(APP_DIR);
     create_dir_all(app_dir.clone()).expect("Failed to create Application path");
 
@@ -142,9 +138,8 @@ pub fn get_pkg_manifest() -> Vec<Package> {
 /// Overwrite the manifest with new data
 pub fn update_pkg_manifest(manifest: &Vec<Package>) {
     // First, create the /home/AppImages directory if it doesn't exist
-    let mut app_dir = home_dir().expect(
-        "Um. Somehow you don't have a home directory. You can't use this tool"
-    );
+    let mut app_dir = home_dir()
+        .expect("Um. Somehow you don't have a home directory. You can't use this tool");
     app_dir.push(APP_DIR);
     create_dir_all(app_dir.clone()).expect("Failed to create Application path");
 


### PR DESCRIPTION
It is important to some people that if something goes wrong, they be able to revert the changes.
Often restoration systems can be very complex, which is why I never implemented one for aip-man.
However, I think it is important that aip-man be able to be used in places where a backup is critical, so a rudimentary back up system is necessary imo.

The backup system here is very simple. It creates a tar of ~/Applications called ~/.aipman_backup.tar.gz before doing a command if the `-b/--backup` option is provided.
Then, if something goes wrong in that command or future commands without the -b, the user will be able to restore from that backup via `aipman restore`

Now, this is not a great system. If you have lots of AppImages or a few very large ones, this operation is very slow.
A better system could be one that creates a backup for just files that are being changed in a command. Upgrading from one package to another? Save the old version to restore from.
Another thing we may want to change in the future is having delta changes as well.
The problem is those would take significant development time to be done correctly.

This is an easy and effective solution, so it's the one I'm going with for now, just to get that feature in there.

One other thing to note is there is one more feature that will happen before the release of version 7, so this will not be package in for a little bit longer.