### PR TITLE
More rigidity and implement repo features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+# Rust
 target/
+
+# For testing purposes
+*.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aipman"
-version = "8.0.0"
+version = "9.0.0"
 dependencies = [
  "clap",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aipman"
 authors = [ "Dylan Turner <dylantdmt@gmail.com>" ]
-version = "8.0.0"
+version = "9.0.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "The AppImage Package Manager"
@@ -13,12 +13,12 @@ repository = "https://github.com/blueOkiris/aip-man"
 name = "aipman"
 
 [dependencies]
-clap = { version = "4.1.1", features = [ "derive" ] }
-reqwest = { version = "0.11.13", features = [ "blocking" ] }
+clap = { version = "4.1", features = [ "derive" ] }
+reqwest = { version = "0.11", features = [ "blocking" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0.91"
-dirs = "4.0.0"
-version-compare = "0.1.1"
-flate2 = "1.0.25"
-tar = "0.4.38"
+serde_json = "1.0"
+dirs = "4.0"
+version-compare = "0.1"
+flate2 = "1.0"
+tar = "0.4"
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -20,9 +20,11 @@ pub struct Args {
     pub backup: bool,
 
     /// Use a different package repo than https://github.com/blueOkiris/aip-man-pkg-list.
-    /// Will not be updated.
+    /// To upgrade from that repo, run upgrade with this flag. Works with local repos via file://.
+    /// Should be a link to pkgs.json like:
+    /// https://raw.githubusercontent.com/blueOkiris/aip-man-pkg-list/main/pkgs.json
     #[arg(short, long)]
-    pub repo: bool,
+    pub repo: Option<String>,
 
     /// One of the commands: install <pkg>, remove <pkg>, upgrade, etc.
     #[command(subcommand)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,6 +19,11 @@ pub struct Args {
     #[arg(short, long)]
     pub backup: bool,
 
+    /// Use a different package repo than https://github.com/blueOkiris/aip-man-pkg-list.
+    /// Will not be updated.
+    #[arg(short, long)]
+    pub repo: bool,
+
     /// One of the commands: install <pkg>, remove <pkg>, upgrade, etc.
     #[command(subcommand)]
     pub command: Commands

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,8 +39,8 @@ fn main() {
         create_backup();
     }
     match args.command {
-        Commands::Install { package } => install_package(&package, args.ask),
-        Commands::Remove { package } => remove_package(&package, args.ask),
+        Commands::Install { package } => install_package(&package, args.ask, &args.repo),
+        Commands::Remove { package } => remove_package(&package, args.ask, &args.repo),
         Commands::Upgrade => upgrade_packages(args.ask),
         Commands::List => list_packages(),
         Commands::Run { app, app_args } => run_app(
@@ -72,8 +72,8 @@ fn create_backup() {
 }
 
 /// Attempt to install a package or upgrade to a newer version.
-fn install_package(pkg_name: &str, ask: bool) {
-    let pkg_list = pull_package_list();
+fn install_package(pkg_name: &str, ask: bool, repo: &Option<String>) {
+    let pkg_list = pull_package_list(repo);
 
     if !pkg_list.iter().any(|pkg| pkg.name == pkg_name) {
         println!("Could not find package by the name of '{}'.", pkg_name);
@@ -154,11 +154,11 @@ fn remove_package(pkg_name: &str, ask: bool) {
 }
 
 /// Go through and upgrade all your installed packages.
-fn upgrade_packages(ask: bool) {
+fn upgrade_packages(ask: bool, repo: &Option<String>) {
     println!("Upgrading packages...");
 
     let mut new_manifest = Vec::new();
-    let pkg_list = pull_package_list();
+    let pkg_list = pull_package_list(repo);
     let manifest = get_pkg_manifest();
     for inst_pkg in manifest.iter() {
         if pkg_list.iter().any(|pkg| pkg.name == inst_pkg.name) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,8 @@ fn main() {
     }
     match args.command {
         Commands::Install { package } => install_package(&package, args.ask, &args.repo),
-        Commands::Remove { package } => remove_package(&package, args.ask, &args.repo),
-        Commands::Upgrade => upgrade_packages(args.ask),
+        Commands::Remove { package } => remove_package(&package, args.ask),
+        Commands::Upgrade => upgrade_packages(args.ask, &args.repo),
         Commands::List => list_packages(),
         Commands::Run { app, app_args } => run_app(
             &app, &app_args.unwrap_or(Vec::new()), args.ask

--- a/src/pkg.rs
+++ b/src/pkg.rs
@@ -117,8 +117,9 @@ impl Package {
 ///
 /// Note that this is used to hide complexity from the top level functions, so it cannot return a
 /// result/error. All errors must be handled here.
-pub fn pull_package_list() -> Vec<Package> {
-    let list_json = get(PKG_LIST_URL).expect("Failed to download package list")
+pub fn pull_package_list(repo: &Option<String>) -> Vec<Package> {
+    let url = repo.unwrap_or(PKG_LIST_URL.to_string());
+    let list_json = get(url).expect("Failed to download package list")
         .text().expect("Failed to get package list text");
     from_str(list_json.as_str()).expect("Failed to parse global package list")
 }

--- a/src/pkg.rs
+++ b/src/pkg.rs
@@ -88,9 +88,13 @@ impl Package {
         let mut app_dir = home_dir()
             .expect("Um. Somehow you don't have a home directory. You can't use this tool");
         app_dir.push(APP_DIR);
-        remove_file(format!(
+        match remove_file(format!(
             "{}/{}-{}.AppImage", app_dir.as_os_str().to_str().unwrap(), self.name, self.version
-        )).expect("Failed to delete package");
+            )) {
+            Ok(_) => {},
+            Err(_) =>
+                println!("Warning: Failed to remove file. Manual intervention may be required")
+        }
     }
 
     pub fn run(&self, args: &Vec<String>) {


### PR DESCRIPTION
- Remove no longer panics
   + You can easily delete files in ~/Applications, but a failure means the local list doesn't get updated correctly.
- You can now install from repos outside of the main one
   + Primarily intended for testing
   + Local works too.